### PR TITLE
update sha256 checksums for 0.2.0

### DIFF
--- a/libraries/consul_replicate_installation_archive.rb
+++ b/libraries/consul_replicate_installation_archive.rb
@@ -117,67 +117,67 @@ module ConsulReplicateCookbook
         when 'darwin-i386'
           case resource.version
           when '0.1.0' then '0f1e37457c715942f92bdc2aba039a628d7e036e403fceadb0fcfacfe07dc68e'
-          when '0.2.0' then '223a3f0b9eef6600ac51596ea4074cb1f06d085824a113ecceeb610b01982bd2'
+          when '0.2.0' then '32c75f4fb2ba51763102e8f2fab4ad0e7e09f9fe474959934e37a56930507ee5'
           end
         when 'darwin-amd64'
           case resource.version
           when '0.1.0' then '3ee227d50ce3764552bbe5c9eee3dc73e42c83746abaf684b6999d3116f8e03c'
-          when '0.2.0' then '4d5c944e33630750b5d73ae7f9fc0510322dd60efa04aaefa939bc0d59e93885'
+          when '0.2.0' then '48956988c2f3d963930f48f26fe16c3dee9eede8719de002940f18802195c190'
           end
         when 'freebsd-i386'
           case resource.version
           when '0.1.0' then '3de903b70dd1580a204d0db8fcd5aa1348ab5b4890eefecb0e11a95c550e1474'
-          when '0.2.0' then 'd9fc089d23ca3af597986032294a2cc8e4de8b421022620b275b09cd4ffd256f'
+          when '0.2.0' then 'fdeace1b1dffd58958aad8954263c709c154f4e5c9db767c1b62d352227ce0f9'
           end
         when 'freebsd-amd64'
           case resource.version
           when '0.1.0' then '7914a6d9d21fb0833ad50afa884ae947c4b45a23aa7e58b6878beb087aa0fba7'
-          when '0.2.0' then '0e0eef0588599122c1e8cd1c37d8c821a2401e63c55ad4a792633ca47bdc4dc6'
+          when '0.2.0' then '1b10091f59be4dd0f4c924f337c6002cefd2bc65f115f4641946ca5b27ecb5a2'
           end
         when 'freebsd-arm'
           case resource.version
           when '0.1.0' then 'a3adf8425c93979ed4aa5c1792885bd57739a8079ff46ad1b57c98d75ca86272'
-          when '0.2.0' then '24fb42ff07edfeab8a061c571ee2a35a47f42701b922de82708d80dfb7d41946'
+          when '0.2.0' then '718c6abb0e0efc1b9b9440740ab2bf46c1ec2e77c4b2e55e9e76289460c544e5'
           end
         when 'linux-i386'
           case resource.version
           when '0.1.0' then '1160dcd2bdb8856b7b99e7c3f0256d769bd5a1c80ae42d31bc51bc05a6d7e2ad'
-          when '0.2.0' then '1f23440eda43ddf2998665f280ecbd64b4ae686334207fe569d7d73e96c19bfd'
+          when '0.2.0' then 'ccc522a7a9cacdfae390c6f5b94654d2dcbf3bfcd4bdc7f49d63ce70a307d96b'
           end
         when 'linux-amd64'
           case resource.version
           when '0.1.0' then 'bd383d089791d8eb45fc51035d758ed2fcbe3a603ca44edd785c874c94a54770'
-          when '0.2.0' then '591d073718ec9abeaf5974e9e9d8c058780342c5a14dade059f8082173549fe8'
+          when '0.2.0' then 'cc7ffbc3f78efd303861164cde1f09d5c6fd5854d13d8c318d92a71d2b69447a'
           end
         when 'linux-arm'
           case resource.version
           when '0.1.0' then '1bc1f218d0eb85abcecb508a5972298d39e2703243f24f83a70c415a59cd70b0'
-          when '0.2.0' then 'bbb123af1a553af73f60716b7de844f126549d2f5b3d0694fb6ebfad90c4b944'
+          when '0.2.0' then 'bbfc42dc8904e0fc7cf4bb97feddb1cc7139f9fa1510e8b42ccf9fefbf821a2a'
           end
         when 'netbsd-386'
           case resource.version
           when '0.1.0' then 'f348cc99f241c5105afbec53834d92e9cf07c2854f910ace0473689c5d47a37c'
-          when '0.2.0' then '7dcc18adae95915a021e1e4473ba28b6e1bd1659a11d2929842e0e2635512ee2'
+          when '0.2.0' then '07436456f6e2af64947306568e11231d0c6403461a5be3e9ef8be7ebd50623af'
           end
         when 'netbsd-amd64'
           case resource.version
           when '0.1.0' then '30270b3d634d5e8425aa526a4c0807bfc8e37e78ade16c0cce8eefabe176f1f3'
-          when '0.2.0' then 'f3178ead41c9dda56afa6ef718207f48dad07503e13ad4276ae8454a2bd92f5b'
+          when '0.2.0' then 'c89b8ffbd1646fee8cabe540804864a7bb7ff0ea3bd259c6d96fba62a6c8a6cd'
           end
         when 'netbsd-arm'
           case resource.version
           when '0.1.0' then '869c651d46f9d0aca7c33ad033472b89129dd31afb20b9574ffdcd4df1d590a4'
-          when '0.2.0' then '6d5cc949d565cd8305f0684aae95b7b1cb2d08ed8521f27ca2eed8c1690b5782'
+          when '0.2.0' then 'df59a25ef2d70b827d23d651095d6fbabbd3e4b1d45e12c7797b4efc93369e12'
           end
         when 'openbsd-386'
           case resource.version
           when '0.1.0' then '1c0db1eb4b55632f0e0b761eec5ba750a582e3db39aa76fffc8355f152e3134b'
-          when '0.2.0' then '1ca727580aa999c4375e4b9c41603f4c7d3f347da1c4ca37a2d1fee6f848801b'
+          when '0.2.0' then 'a295d01de396715696d901185cc87ef4d8b807723ee94af2596b66c539992dde'
           end
         when 'openbsd-amd64'
           case resource.version
           when '0.1.0' then '28f3e87564b05ab6cd2ee8aa27398e2df9adbe1a4ffeaeb82c77a1d129528b6c'
-          when '0.2.0' then 'ecaf664fce62706e3d58f9eb2ca66a53ae9eb7787477869959c3f6ebf5512664'
+          when '0.2.0' then '26c073ceadb391d223f5b9e5641792b2b1f9cd180407a6acb23e083ead7a7bd5'
           end
         when 'plan9-386'
           case resource.version
@@ -186,12 +186,12 @@ module ConsulReplicateCookbook
         when 'windows-i386'
           case resource.version
           when '0.1.0' then 'bee29dcaf9a418c878421786669aefb9e912cb716e952779ec11838fe1fdff46'
-          when '0.2.0' then '549e69e4c9e811da3889bb9045df28895bc0a681547e79c33ce29e39f7c7c9ba'
+          when '0.2.0' then '04f3b3a97eb7599c5a6f92841caf58300e62b1ac089ea3b8e29bd360ed04aaeb'
           end
         when 'windows-amd64'
           case resource.version
           when '0.1.0' then '936f4cee0f49f08b3781f0555134b56ce755cd748f38cafc42312805a12f3853'
-          when '0.2.0' then '8cdd86c6e184eae627dfcdc56a28de86c80076433a563f8147ad41f8a8fa5ea0'
+          when '0.2.0' then '1c0ca471901ea9f6954f17c515a4c7367241bf7ba40e664b18157412614e8580'
           end
         end
       end


### PR DESCRIPTION
Hashicorp updated archives (see https://releases.hashicorp.com/consul-replicate/0.2.0/consul-replicate_0.2.0_SHA256SUMS). 
