### PR TITLE
Fixes for consul_replicate_config resource

### DIFF
--- a/libraries/consul_replicate_config.rb
+++ b/libraries/consul_replicate_config.rb
@@ -66,7 +66,7 @@ module ConsulReplicateCookbook
       attribute(:auth_password, kind_of: String)
       # @!attribute prefix
       # @return [Array]
-      attribute(:prefix, kind_of: Array[Hash], default: [])
+      attribute(:prefix, kind_of: Array, default: [])
 
       def variables
         {
@@ -76,21 +76,24 @@ module ConsulReplicateCookbook
           log_level: log_level,
           prefix: prefix
         }.tap do |h|
-          h['token'] = token if token
-          h['wait'] = wait if wait
+          h['token'] = token unless token.nil?
+          h['wait'] = wait unless wait.nil?
 
           if auth_enabled
+            h['auth'] = Hash.new
             h['auth']['enabled'] = true
             h['auth']['username'] = auth_username
             h['auth']['password'] = auth_password
           end
 
           if syslog_enabled
+            h['syslog'] = Hash.new
             h['syslog']['enabled'] = true
             h['syslog']['facility'] = syslog_facility
           end
 
           if ssl_enabled
+            h['ssl'] = Hash.new
             h['ssl']['enabled'] = true
             h['ssl']['verify'] = ssl_verify
             h['ssl']['cert'] = ssl_cert

--- a/libraries/consul_replicate_config.rb
+++ b/libraries/consul_replicate_config.rb
@@ -80,20 +80,20 @@ module ConsulReplicateCookbook
           h['wait'] = wait unless wait.nil?
 
           if auth_enabled
-            h['auth'] = Hash.new
+            h['auth'] = {}
             h['auth']['enabled'] = true
             h['auth']['username'] = auth_username
             h['auth']['password'] = auth_password
           end
 
           if syslog_enabled
-            h['syslog'] = Hash.new
+            h['syslog'] = {}
             h['syslog']['enabled'] = true
             h['syslog']['facility'] = syslog_facility
           end
 
           if ssl_enabled
-            h['ssl'] = Hash.new
+            h['ssl'] = {}
             h['ssl']['enabled'] = true
             h['ssl']['verify'] = ssl_verify
             h['ssl']['cert'] = ssl_cert

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,11 +25,12 @@ config = consul_replicate_config node['consul-replicate']['service_name'] do |r|
   if node['consul-replicate']['config']
     node['consul-replicate']['config'].each_pair { |k, v| r.send(k, v) }
   end
-  notifies :reload, "poise_service[#{name}]", :delayed
 end
 
 poise_service node['consul-replicate']['service_name'] do
   command "#{consul.program} -config #{config.path}"
   user node['consul-replicate']['service_user']
   directory node['consul-replicate']['service_directory']
+  subscribes :reload, "rc_file[#{config.path}]", :delayed
 end
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,4 +33,3 @@ poise_service node['consul-replicate']['service_name'] do
   directory node['consul-replicate']['service_directory']
   subscribes :reload, "rc_file[#{config.path}]", :delayed
 end
-


### PR DESCRIPTION
libraries/consul_replicate_config.rb
1. Got `undefined method``[]=' for nil:NilClass`` error in case "wait" is not defined(nil) in the attribute.  fixed it by using unless .nil? to treat 'nil' as false for sure
2. Couldn't configure "prefix" option including multiple sources because of the type definition of prefix attribute. - this should be just "Array"
3. syslog,ssl,auth : required a parent hash to be initialized before inserting values 

recipes/default.rb
notifying from config resource to daemon won't do anything as this resource is just a wrapper to create rc_file and this rc_file should be watched to let daemon aware of the config changes.

Also, since I have experienced [this issue](https://github.com/johnbellone/consul-replicate-cookbook/issues/2) first, I tried to use 0.1.0 but daemon init configuration and configuration options were totally based on 0.2.0 and this cookbook didn't work for 0.1.0. I suppose this should be documented.
