### PR TITLE
Download and Unpack Archive

### DIFF
--- a/libraries/consul_replicate_installation_archive.rb
+++ b/libraries/consul_replicate_installation_archive.rb
@@ -42,18 +42,16 @@ module ConsulReplicateCookbook
             recursive true
           end
 
-          poise_archive ::File.basename(url) do
-            action :nothing
-            path ::File.join(Chef::Config[:file_cache_path], name)
-            destination consul_base
-            strip_components 0
-          end
-
           remote_file ::File.basename(url) do
-            action :nothing
             source url
             checksum options[:archive_checksum]
             path ::File.join(Chef::Config[:file_cache_path], name)
+          end
+
+          poise_archive ::File.basename(url) do
+            path ::File.join(Chef::Config[:file_cache_path], name)
+            destination consul_base
+            strip_components 0
           end
 
           file program do


### PR DESCRIPTION
The default recipe fails to run consul-replicate assuming usage would look something like:

```
node.default["consul-replicate"]["config"] = {
  prefix: [{ source: "global@nyc1" }]
}

include_recipe "consul-replicate"
```

The `remote_file` and `poise_archive` resources' actions were previously set to :nothing. At no point is the default recipe notifying these resources to perform their :unpack/:create actions so the archive is never downloaded or unpacked. Using each's default action when the resource is defined does the work.
