### PR TITLE
Add exclude option, used to exclude specific prefixes

### DIFF
--- a/libraries/consul_replicate_config.rb
+++ b/libraries/consul_replicate_config.rb
@@ -67,6 +67,9 @@ module ConsulReplicateCookbook
       # @!attribute prefix
       # @return [Array]
       attribute(:prefix, kind_of: Array, default: [])
+      # @!attribute exclude
+      # @return [Array]
+      attribute(:exclude, kind_of: Array, default: [])
 
       def variables
         {
@@ -78,6 +81,7 @@ module ConsulReplicateCookbook
         }.tap do |h|
           h['token'] = token unless token.nil?
           h['wait'] = wait unless wait.nil?
+          h['exclude'] = exclude unless exclude.empty?
 
           if auth_enabled
             h['auth'] = {}


### PR DESCRIPTION
Works opposite of the `prefix` option.

Useful to watch an umbrella prefix and then exclude specific sub prefixes.

This option is currently only available in the master branch of `consul-replicate` (hashicorp/consul-replicate#51), but should be available upon next release.

Fixes #5