### PR TITLE
Various small fixes so travis will be happy

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -26,6 +26,8 @@ platforms:
       poise-service:
         consul:
           provider: systemd
+        consul-replicate:
+          provider: systemd
   - name: centos-6
     named_run_list: centos
     driver:
@@ -45,6 +47,8 @@ platforms:
     attributes:
       poise-service:
         consul:
+          provider: systemd
+        consul-replicate:
           provider: systemd
   - name: ubuntu-14.04
     named_run_list: debian
@@ -81,6 +85,6 @@ platforms:
       pid_one_command: /sbin/init
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install lsb-release sudo -y
+        - RUN /usr/bin/apt-get install procps lsb-release sudo -y
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,8 @@ maintainer 'John Bellone'
 maintainer_email 'jbellone@bloomberg.net'
 description 'Application cookbook which installs and configures Consul Replicate'
 long_description 'Application cookbook which installs and configures Consul Replicate'
+issues_url 'https://github.com/johnbellone/consul-replicate-cookbook/issues'
+source_url 'https://github.com/johnbellone/consul-replicate-cookbook'
 version '0.4.0'
 
 supports 'redhat', '>= 5.8'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -14,7 +14,6 @@ describe process('consul-replicate') do
   it { should be_running }
 end
 
-
 describe user('consul') do
   it { should exist }
 end


### PR DESCRIPTION
poise_service doesn't like systemd (or upstart) in docker

consul was already forced to be managed by systemd, now forcing consul-replicate as well (although I think you might as well set the default for everything to systemd on these systems, including debian:8, just to be on the save side, let me know if you want that and I'll update the PR).

The debian:7 docker image was a lot more minimal than 8 and therefore was missing some basic tools that busser used for spec'cing.

Also fixed tiny foodcritic criticism and I am allergic to any dangling whitespace I see ;)